### PR TITLE
Fix redundant event emission in EcoCoin

### DIFF
--- a/contracts/ecoCoin.sol
+++ b/contracts/ecoCoin.sol
@@ -15,7 +15,6 @@ contract EcoCoin is ERC20, Ownable {
     function mintTokens(address account, uint256 amount) external onlyOwner {
         require(totalSupply() + amount <= maxSupply, "Total supply cannot exceed maximum supply");
         _mint(account, amount);
-        emit Transfer(address(0), account, amount);
     }
 
     function withdraw() public onlyOwner {


### PR DESCRIPTION
## Summary
- remove manual Transfer event emission in `mintTokens`

## Testing
- `npx hardhat test` *(fails: unable to access npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_687549138738833387267dfb00fe7273