### PR TITLE
Improve frontend error handling

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -37,7 +37,13 @@ async function updateBalance() {
     ecoCoinContract = new ethers.Contract(ecoCoinAddress, ecoCoinAbi, provider);
   }
   const addr = await signer.getAddress();
-  const bal  = await ecoCoinContract.balanceOf(addr);
+  let bal;
+  try {
+    bal = await ecoCoinContract.balanceOf(addr);
+  } catch (err) {
+    console.warn('[updateBalance] balanceOf failed →', err);
+    bal = 0n;
+  }
   document.getElementById('walletAddress').textContent = clip(addr);
   document.getElementById('walletBalance').textContent = ethers.formatEther(bal) + ' ECO';
 }


### PR DESCRIPTION
## Summary
- catch `balanceOf` errors in the frontend so the page doesn't crash

## Testing
- `npx hardhat test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68780bb064808333ad6db27a11b59c14